### PR TITLE
Smoke test and e2e test to verify OpenStack runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,16 @@ start-validate-%:
 	@mkdir -p molecule/log/$*
 	@mkdir -p molecule/$*/results/$$TARGET_ENV/expected
 	@date=`(date "+%Y_%m_%d_%H_%M_%N")`; \
-	SCENARIO=$* LOG_FILE=$$TARGET_ENV-$$date molecule -c molecule/config.yml test -s $* --report --command-borders
+	SCENARIO=$* LOG_FILE=$$TARGET_ENV-$$date molecule -c molecule/config.yml check -s $* --report --command-borders
 	@rm -rf molecule/$*/results/$$TARGET_ENV/actual
+
+test-ceph:
+	@$(MAKE) start-test-ceph TARGET_ENV=local
+
+test-openstack:
+	@$(MAKE) start-test-openstack TARGET_ENV=local
+
+start-test-%:
+	@mkdir -p molecule/log/$*
+	@date=`(date "+%Y_%m_%d_%H_%M_%N")`; \
+	SCENARIO=$* LOG_FILE=$$TARGET_ENV-$$date molecule -c molecule/config.yml test -s $* --report --command-borders

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Start with the repository-backed docs when learning or changing this project:
 * VM provisioning: Vagrant
 * Configuration management: Ansible
 * OpenStack release: Gazpacho / 2026.1 (`cloud-archive:gazpacho`)
-* Storage backend: Ceph
+* Storage backend: Glance file storage and Cinder LVM by default; optional Ceph/RBD integration
 * Observability: OpenSearch, Prometheus, Grafana stack
 * Optional workloads:
 
@@ -80,13 +80,15 @@ python3 -m pip install -r requirements.txt
 ## Important Notes Before Deploy
 
 1. **Recommended deployment order**
-   - Vagrant VM setup -> Ceph deployment -> OpenStack deployment -> OpenStack bootstrap -> optional stacks (observability, CI/CD, Kubernetes).
+   - Default path: Vagrant VM setup -> OpenStack deployment -> OpenStack bootstrap -> optional stacks (observability, CI/CD, Kubernetes).
+   - Ceph path: Vagrant VM setup -> Ceph deployment -> OpenStack deployment with Ceph enabled -> OpenStack bootstrap -> optional stacks.
 
-2. **Ceph is enabled by default in OpenStack playbooks**
-   - `deploy_openstack` has `ceph_enabled: true` by default.
-   - Run Ceph playbooks first so Ceph artifacts are available for OpenStack integration.
-   - If you want to skip Ceph, set `ceph_enabled: false` in:
+2. **Ceph is disabled by default in OpenStack playbooks**
+   - `deploy_openstack` has `ceph_enabled: false` by default.
+   - The default OpenStack deployment uses Glance file storage and the Cinder LVM backend.
+   - If you want Ceph-backed Glance, Cinder, and Nova integration, set `ceph_enabled: true` in:
      `ansible/deploy_openstack/inventories/local/group_vars/all/common.yml`.
+   - Run Ceph playbooks first when Ceph is enabled so Ceph artifacts are available for OpenStack integration.
 
 3. **Credentials in repository are insecure defaults**
    - Files under `ansible/**/group_vars/*secret*.yml` use static sample credentials.
@@ -152,6 +154,9 @@ python3 -m pip install -r requirements.txt
 
 ## Ceph Provisioning
 
+Ceph provisioning is optional for the default lab. Run it when you want the
+OpenStack deployment to use Ceph/RBD by setting `ceph_enabled: true`.
+
 All Ceph provisioning is done using Ansible.
 
 1. Load environment variables and navigate to Ansible:
@@ -211,8 +216,8 @@ ansible-playbook -i deploy_ceph/inventories/local/local.yml \
 
 ## OpenStack Provisioning
 
-> **Important:** Run Ceph provisioning first unless you explicitly disable Ceph integration in
-> `ansible/deploy_openstack/inventories/local/group_vars/all/common.yml`.
+> **Important:** Ceph integration is disabled by default. Run Ceph provisioning first only when
+> `ceph_enabled: true` in `ansible/deploy_openstack/inventories/local/group_vars/all/common.yml`.
 
 1. Load environment variables and navigate to Ansible:
 
@@ -249,6 +254,13 @@ ansible-playbook -i deploy_ceph/inventories/local/local.yml \
      ```bash
      ansible-playbook -i deploy_openstack/inventories/local/local.yml \
        deploy_openstack/playbook_setup_storage.yml
+     ```
+
+   * Ceph integration, only when `ceph_enabled: true`:
+
+     ```bash
+     ansible-playbook -i deploy_openstack/inventories/local/local.yml \
+       deploy_openstack/playbook_ceph_integration.yml
      ```
 
 ### One-step OpenStack deployment
@@ -523,7 +535,8 @@ This provisions a **kubeadm-based Kubernetes cluster** on OpenStack.
 ## Troubleshooting
 
 1. **OpenStack pre-setup fails on Ceph files in `/tmp/fetch-ceph*`**
-   - Run Ceph deployment first (`deploy_ceph/playbook_deploy.yml`), or disable Ceph with `ceph_enabled: false`.
+   - This path is only expected when `ceph_enabled: true`.
+   - Run Ceph deployment first (`deploy_ceph/playbook_deploy.yml`), or return to the default local storage path with `ceph_enabled: false`.
 
 2. **Ansible fails with callback plugin error**
    - Install `merizrizal.utils` collection, then rerun playbook.

--- a/ansible/cicd_in_openstack/roles/gitlab/tasks/main.yml
+++ b/ansible/cicd_in_openstack/roles/gitlab/tasks/main.yml
@@ -52,5 +52,5 @@
   vars:
     ip_addr_cidr: "{{ ansible_host | ansible.utils.ipsubnet(16) }}"
   register: configure_settings
-  changed_when: '"true" in configure_settings.stdout'
-  failed_when: '"false" in configure_settings.stdout'
+  changed_when: "'true' in configure_settings.stdout"
+  failed_when: "'false' in configure_settings.stdout"

--- a/ansible/cicd_in_openstack/roles/gitlab/tasks/setup_user.yml
+++ b/ansible/cicd_in_openstack/roles/gitlab/tasks/setup_user.yml
@@ -11,10 +11,10 @@
       EOF
     executable: /bin/bash
   register: change_root_password
-  changed_when: '"true" in change_root_password.stdout'
+  changed_when: "'true' in change_root_password.stdout"
   failed_when: >
-    "false" in change_root_password.stdout or "ERROR" in change_root_password.stdout or "error" in change_root_password.stdout or
-    (change_root_password.stderr is defined and change_root_password.stderr != "" and change_root_password.rc != 0)
+    'false' in change_root_password.stdout or 'ERROR' in change_root_password.stdout or 'error' in change_root_password.stdout or
+    (change_root_password.stderr is defined and change_root_password.stderr != '' and change_root_password.rc != 0)
 
 - name: Create root PAT
   ansible.builtin.shell:
@@ -31,11 +31,11 @@
       EOF
     executable: /bin/bash
   register: create_root_pat
-  changed_when: '"true" in create_root_pat.stdout and "duplicate key value" not in create_root_pat.stdout'
+  changed_when: "'true' in create_root_pat.stdout and 'duplicate key value' not in create_root_pat.stdout"
   failed_when: >
-    "false" in create_root_pat.stdout or
-    (("ERROR" in create_root_pat.stdout or "error" in create_root_pat.stdout) and "duplicate key value" not in create_root_pat.stdout) or
-    (create_root_pat.stderr is defined and create_root_pat.stderr != "" and create_root_pat.rc != 0)
+    'false' in create_root_pat.stdout or
+    (('ERROR' in create_root_pat.stdout or 'error' in create_root_pat.stdout) and 'duplicate key value' not in create_root_pat.stdout) or
+    (create_root_pat.stderr is defined and create_root_pat.stderr != '' and create_root_pat.rc != 0)
 
 - name: Create standard user
   ansible.builtin.uri:
@@ -55,5 +55,5 @@
   changed_when: create_standard_user.json.id is defined
   failed_when: >
     (create_standard_user.status != 200 and create_standard_user.status != 201 and
-    create_standard_user.json.message is defined and "has already been taken" not in create_standard_user.json.message) or
-    (create_standard_user.msg is defined and "Connection refused" in create_standard_user.msg)
+    create_standard_user.json.message is defined and 'has already been taken' not in create_standard_user.json.message) or
+    (create_standard_user.msg is defined and 'Connection refused' in create_standard_user.msg)

--- a/ansible/cicd_in_openstack/roles/runner/tasks/gitlab.yml
+++ b/ansible/cicd_in_openstack/roles/runner/tasks/gitlab.yml
@@ -66,8 +66,8 @@
   register: register_gitlab_runner
   when: >
     not runner_config_file.stat.exists or
-    (runner_availability.stdout is defined and runner_availability.stdout == "")
-  changed_when: register_gitlab_runner.stderr is defined and "has already been registered" not in register_gitlab_runner.stderr
+    (runner_availability.stdout is defined and runner_availability.stdout == '')
+  changed_when: register_gitlab_runner.stderr is defined and 'has already been registered' not in register_gitlab_runner.stderr
 
 - name: Create workspace directory for runner
   ansible.builtin.file:

--- a/ansible/cicd_in_openstack/roles/runner/tasks/main.yml
+++ b/ansible/cicd_in_openstack/roles/runner/tasks/main.yml
@@ -9,9 +9,9 @@
 - name: Install Gitlab Runner
   ansible.builtin.include_tasks:
     file: gitlab.yml
-  when: '"gitlab" in runner_agent'
+  when: "'gitlab' in runner_agent"
 
 - name: Install Jenkins Runner
   ansible.builtin.include_tasks:
     file: jenkins.yml
-  when: '"jenkins" in runner_agent'
+  when: "'jenkins' in runner_agent"

--- a/ansible/deploy_openstack/inventories/local/group_vars/all/common.yml
+++ b/ansible/deploy_openstack/inventories/local/group_vars/all/common.yml
@@ -9,4 +9,4 @@ controller01_host_addr: "{{ use_hostname | ternary(controller01.hostname, contro
 compute01_host_addr: "{{ use_hostname | ternary(compute01.hostname, compute01.mgmtnet_ip_address) }}"
 storage01_host_addr: "{{ use_hostname | ternary(storage01.hostname, storage01.mgmtnet_ip_address) }}"
 
-ceph_enabled: true
+ceph_enabled: false

--- a/ansible/deploy_openstack/roles/cinder_storage/tasks/main.yml
+++ b/ansible/deploy_openstack/roles/cinder_storage/tasks/main.yml
@@ -18,8 +18,8 @@
   changed_when: false
   failed_when: >
     prepare_volume.stderr is defined and
-    prepare_volume.stderr != "" and
-    "already exists" not in prepare_volume.stderr
+    prepare_volume.stderr != '' and
+    'already exists' not in prepare_volume.stderr
 
 - name: Reconfigure lvm.conf - set devices/filter
   ansible.builtin.replace:

--- a/ansible/deploy_openstack/roles/common/tasks/configure_service.yml
+++ b/ansible/deploy_openstack/roles/common/tasks/configure_service.yml
@@ -33,7 +33,7 @@
 - name: Create public component service API endpoints
   ansible.builtin.command:
     cmd: openstack endpoint create --region RegionOne {{ service_name }} public {{ service_endpoint_url }}
-  when: public_endpoint.stdout is defined and public_endpoint.stdout == ""
+  when: public_endpoint.stdout is defined and public_endpoint.stdout == ''
   changed_when: true
 
 - name: Check internal component service API endpoints
@@ -48,7 +48,7 @@
 - name: Create internal component service API endpoints
   ansible.builtin.command:
     cmd: openstack endpoint create --region RegionOne {{ service_name }} internal {{ service_endpoint_url }}
-  when: internal_endpoint.stdout is defined and internal_endpoint.stdout == ""
+  when: internal_endpoint.stdout is defined and internal_endpoint.stdout == ''
   changed_when: true
 
 - name: Check admin component service API endpoints
@@ -63,5 +63,5 @@
 - name: Create admin component service API endpoints
   ansible.builtin.command:
     cmd: openstack endpoint create --region RegionOne {{ service_name }} admin {{ service_endpoint_url }}
-  when: admin_endpoint.stdout is defined and admin_endpoint.stdout == ""
+  when: admin_endpoint.stdout is defined and admin_endpoint.stdout == ''
   changed_when: true

--- a/ansible/deploy_openstack/roles/common/tasks/create_user_and_roles.yml
+++ b/ansible/deploy_openstack/roles/common/tasks/create_user_and_roles.yml
@@ -3,8 +3,8 @@
   ansible.builtin.command:
     cmd: openstack user create --domain default --password '{{ os_component.password }}' {{ os_component.name }}
   register: create_component_user
-  changed_when: create_component_user.stdout is defined and "password_expires_at" in create_component_user.stdout
-  failed_when: create_component_user.rc != 0 and "ConflictException" not in create_component_user.stderr
+  changed_when: create_component_user.stdout is defined and 'password_expires_at' in create_component_user.stdout
+  failed_when: create_component_user.rc != 0 and 'ConflictException' not in create_component_user.stderr
 
 - name: Add the certain role to the component user and service project
   ansible.builtin.command:

--- a/ansible/deploy_openstack/roles/neutron/tasks/main.yml
+++ b/ansible/deploy_openstack/roles/neutron/tasks/main.yml
@@ -29,9 +29,9 @@
     executable: /bin/bash
   register: add_br_prvdr
   failed_when: >
-    add_br_prvdr.stderr is defined and add_br_prvdr.stderr != ""
-    and "already exists" is not in add_br_prvdr.stderr
-  changed_when: add_br_prvdr.rc == 0 and add_br_prvdr.stderr is defined and add_br_prvdr.stderr == ""
+    add_br_prvdr.stderr is defined and add_br_prvdr.stderr != ''
+    and 'already exists' is not in add_br_prvdr.stderr
+  changed_when: add_br_prvdr.rc == 0 and add_br_prvdr.stderr is defined and add_br_prvdr.stderr == ''
 
 - name: Re-configure provider interface
   ansible.builtin.template:

--- a/ansible/kubernetes_in_openstack/roles/kubernetes/tasks/install_kata_containers.yml
+++ b/ansible/kubernetes_in_openstack/roles/kubernetes/tasks/install_kata_containers.yml
@@ -42,14 +42,14 @@
     chdir: /home/{{ ansible_user }}
     cmd: ./{{ kata_manager_url | basename }} -o -k {{ kata_version }}
   register: kata_containers
-  changed_when: kata_containers.stdout is defined and "Kata Containers is now installed" in kata_containers.stdout
+  changed_when: kata_containers.stdout is defined and 'Kata Containers is now installed' in kata_containers.stdout
   failed_when: >
-    (kata_containers.stderr is defined and kata_containers.stderr != "" and "Please remove existing Kata Containers" not in kata_containers.stderr)
-    and (kata_containers.stdout is defined and "Kata Containers is now installed" not in kata_containers.stdout)
+    (kata_containers.stderr is defined and kata_containers.stderr != '' and 'Please remove existing Kata Containers' not in kata_containers.stderr)
+    and (kata_containers.stdout is defined and 'Kata Containers is now installed' not in kata_containers.stdout)
   retries: 5
   until: >
-    (kata_containers.stdout is defined and "Kata Containers is now installed" in kata_containers.stdout)
-    or (kata_containers.stderr is defined and "Please remove existing Kata Containers" in kata_containers.stderr)
+    (kata_containers.stdout is defined and 'Kata Containers is now installed' in kata_containers.stdout)
+    or (kata_containers.stderr is defined and 'Please remove existing Kata Containers' in kata_containers.stderr)
 
 - name: Remove containerd-shim-kata-v2 from /usr/bin
   ansible.builtin.file:

--- a/ansible/shared_resources/playbooks/roles/docker/tasks/install_docker.yml
+++ b/ansible/shared_resources/playbooks/roles/docker/tasks/install_docker.yml
@@ -17,7 +17,7 @@
     - name: Check if the OS distribution is Ubuntu
       ansible.builtin.fail:
         msg: The OS distribution is not Ubuntu, go to rescue block
-      when: '"Ubuntu" not in ansible_facts["distribution"]'
+      when: "'Ubuntu' not in ansible_facts['distribution']"
 
     - name: Create directory for Docker's GPG key
       ansible.builtin.file:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,11 @@ Primary entrypoint is `README.md` with Vagrant-first VM creation and Ansible-fir
 3. Workload layer:
    - OpenStack bootstraps tenant resources and then launches CI/CD and Kubernetes VMs via OpenStack APIs.
 4. Validation layer:
-   - Molecule validates inventory variable contracts, not full functional end-to-end behavior.
+   - Molecule `check` validates inventory variable contracts through
+     `molecule/vars_validation.yml`.
+   - Molecule `test` runs smoke runtime verification through
+     `molecule/verify.yml` by default, with end-to-end verification available
+     behind an opt-in flag.
 
 There is also a shell bootstrap layer in `envrc`:
 
@@ -129,7 +133,14 @@ Local quality gate:
 
 Validation behavior:
 
-- Molecule verifies inventory variable snapshots against checked-in expected JSON, not service reachability or runtime correctness.
+- `make validate-openstack` and `make validate-ceph` run `molecule check`.
+  The `check_sequence` calls `molecule/vars_validation.yml` directly and
+  verifies inventory variable snapshots against checked-in expected JSON.
+- `make test-openstack` and `make test-ceph` run `molecule test`. The
+  `test_sequence` calls `molecule/verify.yml`, which loads scenario smoke checks
+  from `molecule/<scenario>/tasks/smoke_verify.yml` by default.
+- `MOLECULE_E2E_VERIFY=true` enables the OpenStack workload lifecycle test from
+  `molecule/openstack/tasks/e2e_workload_verify.yml`.
 
 ## 7) Engineering Perspective
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 This repository is a lab platform to provision and operate:
 
 - Core OpenStack (controller, compute, storage).
-- Ceph storage backend integration.
+- Optional Ceph storage backend integration.
 - Observability stack (OpenSearch, Prometheus, Grafana).
 - Optional OpenStack-hosted CI/CD lab (GitLab, Jenkins, runner, telemetry).
 - Optional OpenStack-hosted Kubernetes lab (kubeadm-based).
@@ -93,8 +93,8 @@ Inventory boundaries are explicit and matter operationally:
 Recommended dependency order implemented in playbooks:
 
 1. Build base image + spin VMs with Vagrant.
-2. Deploy Ceph (`deploy_ceph/*`) and export keyrings/config.
-3. Deploy OpenStack (`deploy_openstack/*`) with Ceph integration.
+2. Optional: deploy Ceph (`deploy_ceph/*`) and export keyrings/config when using `ceph_enabled: true`.
+3. Deploy OpenStack (`deploy_openstack/*`) with local storage by default, or with Ceph integration when explicitly enabled.
 4. Bootstrap OpenStack resources (`bootstrap_openstack/playbook_bootstrap.yml`).
 5. Deploy optional stacks:
    - Observability (`deploy_opensearch`, `deploy_prometheus`).
@@ -103,9 +103,9 @@ Recommended dependency order implemented in playbooks:
 
 Important hidden coupling:
 
-- OpenStack pre-setup enables Ceph path by default (`ceph_enabled: true`) and copies Ceph config from `/tmp/fetch-ceph.conf`.
-- That file is produced by Ceph-side fetch tasks, so Ceph initialization effectively precedes OpenStack in default mode.
-- Step-by-step OpenStack deployment also needs `playbook_ceph_integration.yml` if Ceph remains enabled, because the one-shot deploy imports it conditionally.
+- OpenStack pre-setup skips the Ceph path by default (`ceph_enabled: false`).
+- When `ceph_enabled: true`, OpenStack copies Ceph config from `/tmp/fetch-ceph.conf`; that file is produced by Ceph-side fetch tasks, so Ceph initialization must precede OpenStack in Ceph-backed mode.
+- Step-by-step OpenStack deployment also needs `playbook_ceph_integration.yml` if Ceph is enabled, because the one-shot deploy imports it conditionally.
 - Guest metadata depends on both Neutron metadata agent and Nova metadata API. In the current Gazpacho implementation, Nova metadata is exposed through Apache on `controller01:8775` using `/usr/bin/nova-metadata-wsgi`.
 - CI/CD and Kubernetes domains depend on generated clouds config files under `generated/` and on the OpenStack inventory plugin grouping hosts as expected.
 

--- a/docs/base-knowledge.md
+++ b/docs/base-knowledge.md
@@ -15,8 +15,9 @@ main layers:
      memory, CPU, disk size, and node purpose.
 2. Infrastructure services:
    - Ansible installs Ceph and OpenStack services on the Vagrant VMs.
-   - Ceph provides the default storage backend for OpenStack image, compute,
-     and volume workflows.
+   - OpenStack uses Glance file storage and Cinder LVM by default.
+   - Ceph can optionally provide RBD-backed image, compute, and volume
+     workflows when `ceph_enabled: true`.
 3. OpenStack-hosted labs:
    - After OpenStack works, Ansible can create tenant VMs inside OpenStack for
      CI/CD and Kubernetes labs.
@@ -26,8 +27,11 @@ main layers:
 The most important dependency chain is:
 
 ```text
-host tools -> Vagrant VMs -> Ceph -> OpenStack -> OpenStack bootstrap -> optional labs
+host tools -> Vagrant VMs -> OpenStack -> OpenStack bootstrap -> optional labs
 ```
+
+When Ceph integration is enabled, insert Ceph deployment before OpenStack so the
+OpenStack playbooks can consume exported Ceph artifacts.
 
 ## 2) Default Node Roles
 
@@ -105,15 +109,16 @@ guest 169.254.169.254 -> Neutron metadata agent -> Nova metadata API on controll
 
 ## 5) Ceph Integration Model
 
-Ceph is enabled by default for OpenStack with:
+Ceph is disabled by default for OpenStack with:
 
 ```yaml
-ceph_enabled: true
+ceph_enabled: false
 ```
 
-The Ceph deployment prepares OpenStack-facing artifacts and fetches them to the
-machine running Ansible. The OpenStack playbooks later consume those files from
-`/tmp`:
+With this default, Glance uses file storage and Cinder uses the local LVM
+backend. When `ceph_enabled: true`, the Ceph deployment prepares
+OpenStack-facing artifacts and fetches them to the machine running Ansible. The
+OpenStack playbooks later consume those files from `/tmp`:
 
 | Artifact | Default local path | Consumer |
 | --- | --- | --- |
@@ -122,9 +127,9 @@ machine running Ansible. The OpenStack playbooks later consume those files from
 | Cinder keyring | `/tmp/fetch-ceph.client.cinder.keyring` | Cinder and Nova integration |
 | Ceph public key | `/tmp/fetch-ceph.pub` | Multi-node Ceph host enrollment |
 
-Because of this coupling, default OpenStack deployment expects Ceph deployment
-and `deploy_ceph/playbook_openstack_init.yml` to run first. If you do not want
-Ceph, set `ceph_enabled: false` before running OpenStack playbooks.
+Because of this coupling, Ceph-enabled OpenStack deployment expects Ceph
+deployment and `deploy_ceph/playbook_openstack_init.yml` to run first. Leave
+`ceph_enabled: false` for the default local storage path.
 
 ## 6) Inventory and Variable Boundaries
 

--- a/docs/base-knowledge.md
+++ b/docs/base-knowledge.md
@@ -180,7 +180,7 @@ The default OpenStack and Ceph inventories use the base-image-created
 | `ansible/cicd_in_openstack/` | Configure GitLab, Jenkins, runner, and CI monitor inside OpenStack VMs |
 | `ansible/kubernetes_in_openstack/` | Configure a kubeadm Kubernetes cluster inside OpenStack VMs |
 | `ansible/shared_resources/` | Shared roles and downstream lab VM definitions |
-| `molecule/` | Inventory-variable validation scenarios |
+| `molecule/` | Molecule variable validation, smoke verification, and end-to-end verification scenarios |
 | `docs/` | Architecture, workflows, quality notes, findings, and this base guide |
 
 ## 9) Editing Guide for Common Changes
@@ -198,8 +198,19 @@ The default OpenStack and Ceph inventories use the base-image-created
 
 ## 10) Validation Mindset
 
-Molecule in this repository validates inventory variable shape. It does not
-prove that OpenStack, Ceph, networking, or downstream workloads are healthy.
+Molecule has two validation paths in this repository:
+
+- `molecule check` validates inventory variable shape through
+  `molecule/vars_validation.yml`. The Makefile exposes this as
+  `make validate-openstack` and `make validate-ceph`.
+- `molecule test` runs runtime verification through `molecule/verify.yml`.
+  The Makefile exposes this as `make test-openstack` and
+  `make test-ceph`. Smoke checks run by default in this path when the
+  scenario has `smoke_verify.yml`; OpenStack end-to-end workload verification is
+  opt-in with `MOLECULE_E2E_VERIFY=true`.
+
+The default CI-oriented validation path still does not deploy the lab by itself,
+so treat smoke and end-to-end checks as deployed-lab verification.
 
 After each major stage, validate the running system:
 

--- a/docs/documentation-audit.md
+++ b/docs/documentation-audit.md
@@ -20,6 +20,9 @@ This note captures documentation mismatches found while reconciling `docs/` with
 4. Added concrete stage validation checkpoints to the workflow guide.
    - `docs/workflows.md` now includes checks after Vagrant, Ceph, OpenStack, OpenStack bootstrap, observability, and dynamic-inventory lab setup.
    - This closes the previous gap where validation advice was mostly conceptual.
+   - The workflow guide now also separates Molecule variable validation
+     (`molecule check`) from runtime smoke verification (`molecule test`), with
+     end-to-end workload verification kept opt-in.
 
 5. `envrc` does more than export variables.
    - It sets `ROOT_DIR` and `ANSIBLE_CONFIG`, installs the git hook from `githooks/`, checks for Python 3.11-3.14, verifies `pip` and `venv`, and exposes `generate_os_client_config`.
@@ -49,7 +52,9 @@ This note captures documentation mismatches found while reconciling `docs/` with
 
 1. Ceph remains enabled by default for the OpenStack domain.
 2. Node exporter still defaults to port `9200`.
-3. CI only validates inventory-variable contracts through Molecule, not full runtime behavior.
+3. Default CI only validates inventory-variable contracts through Molecule
+   `check`; Molecule `test` now runs smoke checks by default for deployed lab
+   environments, while end-to-end runtime checks remain opt-in.
 4. OpenStack and Ceph local inventories now use `ansible_sys_user`, while several bootstrap/downstream domains still use the `vagrant` account.
 
 ## Remaining Documentation Opportunities

--- a/docs/documentation-audit.md
+++ b/docs/documentation-audit.md
@@ -50,7 +50,7 @@ This note captures documentation mismatches found while reconciling `docs/` with
 
 ## Still True After Review
 
-1. Ceph remains enabled by default for the OpenStack domain.
+1. Ceph is now disabled by default for the OpenStack domain; enable it explicitly with `ceph_enabled: true` when testing the Ceph-backed storage path.
 2. Node exporter still defaults to port `9200`.
 3. Default CI only validates inventory-variable contracts through Molecule
    `check`; Molecule `test` now runs smoke checks by default for deployed lab

--- a/docs/findings-and-recommendations.md
+++ b/docs/findings-and-recommendations.md
@@ -112,14 +112,20 @@ Severity model:
    - Recommendation:
      - Keep `docs/` tied to implementation details and update workflow docs whenever playbook composition or inventory scope changes.
 
-2. Molecule currently validates variables only, not runtime behavior.
+2. Molecule separates variable validation from runtime behavior checks.
    - Evidence:
-     - `molecule/config.yml:26`
+     - `molecule/config.yml:28`
      - `molecule/vars_validation.yml:2`
+     - `molecule/verify.yml:2`
+     - `molecule/openstack/tasks/smoke_verify.yml:1`
+     - `molecule/openstack/tasks/e2e_workload_verify.yml:1`
+     - `molecule/ceph/tasks/smoke_verify.yml:1`
    - Impact:
-     - Regressions in service behavior may pass CI unnoticed.
+     - Regressions in service behavior may pass the default Molecule `check` path unless Molecule `test` is run against a deployed lab.
    - Recommendation:
-     - Add functional verify tasks (API health, service status, endpoint checks).
+     - Run Molecule `test` against deployed lab runners when smoke runtime validation is required.
+     - Run OpenStack end-to-end workload verification with `MOLECULE_E2E_VERIFY=true` through Molecule `test` after bootstrap resources exist.
+     - Keep the smoke task fast and mostly read-only so it can run before the deeper workload test; use the OpenStack scenario for API and integration checks and the Ceph scenario for cluster health checks.
 
 ## Prioritized Remediation Roadmap
 
@@ -132,7 +138,7 @@ Severity model:
    - Add Ceph/OpenStack preflight checks and explicit dependency guardrails.
    - Keep operator-facing docs synchronized with playbook composition and inventory scope.
 3. Medium term (week 2-4):
-   - Add runtime smoke tests in CI (OpenStack, Ceph, Prometheus, OpenSearch).
+   - Run Molecule `test` smoke checks on deployed lab runners where available.
    - Template architecture-specific values (`amd64` hardcoding).
    - Move static Jenkins node definitions to data-driven inventory templates.
 

--- a/docs/findings-and-recommendations.md
+++ b/docs/findings-and-recommendations.md
@@ -49,16 +49,16 @@ Severity model:
    - Recommendation:
      - Scope provisioning to current machine host context, not full inventory loops.
 
-3. OpenStack pre-setup depends on Ceph artifacts in `/tmp` while Ceph is enabled by default.
+3. OpenStack pre-setup depends on Ceph artifacts in `/tmp` when Ceph is enabled.
    - Evidence:
-     - Default enable: `ansible/deploy_openstack/inventories/local/group_vars/all/common.yml:12`
+     - Optional enable flag: `ansible/deploy_openstack/inventories/local/group_vars/all/common.yml:12`
      - Ceph role in pre-setup: `ansible/deploy_openstack/playbook_pre_setup.yml:13`
      - Artifact path default: `ansible/shared_resources/playbooks/roles/ceph_common_vars/defaults/main.yml:5`
      - Artifact consumption: `ansible/deploy_openstack/roles/ceph/tasks/main.yml:8`
    - Impact:
-     - OpenStack pre-setup can fail if Ceph export phase was not run previously.
+     - OpenStack pre-setup can fail if `ceph_enabled: true` and the Ceph export phase was not run previously.
    - Recommendation:
-     - Add explicit preflight checks and clearer failure messaging; optionally disable Ceph by default.
+     - Add explicit preflight checks and clearer failure messaging for the optional Ceph path.
 
 4. Kubernetes containerd config is hardcoded to `linux/amd64`.
    - Evidence:

--- a/docs/quality-assessment.md
+++ b/docs/quality-assessment.md
@@ -12,24 +12,33 @@
    - GitHub and GitLab pipelines both enforce linting and molecule variable checks.
 5. Inventory contract testing:
    - Molecule snapshot validation guards accidental variable-schema drift.
+6. Runtime verification:
+   - Molecule `test` runs smoke checks by default and can run the OpenStack
+     workload lifecycle against a deployed lab when enabled.
 
 ## 2) Testing Posture
 
 Current test scope:
 
 - Linting with `ansible-lint`.
-- Molecule variable validation against expected JSON snapshots.
+- Molecule `check` variable validation against expected JSON snapshots.
+- Molecule `test` runtime smoke verification for deployed lab environments.
+- Optional OpenStack end-to-end workload verification with
+  `MOLECULE_E2E_VERIFY=true`.
 
 Missing coverage areas:
 
-- No service-level smoke tests (Keystone token issuance, Nova list, Cinder list, etc.).
-- No integration assertions for network reachability, endpoint availability, or guest metadata reachability.
+- Default CI runs the Molecule `check` path, not the Molecule `test` runtime
+  path, because it does not deploy a live lab.
+- Runtime assertions for network reachability, endpoint availability, and guest
+  metadata reachability require a deployed lab and Molecule `test`.
 - No workload scenario tests for CI/CD and Kubernetes flows.
 
 Net effect:
 
 - High confidence in inventory-variable shape.
-- Moderate/low confidence in runtime system behavior after refactors.
+- Moderate/low confidence in runtime system behavior after refactors unless
+  Molecule `test` runtime verification is run against a deployed lab.
 
 ## 3) Idempotency and Drift Visibility
 
@@ -79,10 +88,16 @@ Main scaling constraints are:
 
 ## 7) Recommended Quality Upgrades
 
-1. Add smoke test playbooks:
-   - OpenStack API checks, Nova metadata API checks on `8775`, Ceph health checks, Prometheus target health, OpenSearch health.
-2. Add minimal end-to-end workload tests:
-   - Boot one VM in OpenStack, verify network attach, volume attach, and delete.
+1. Use Molecule smoke verification after deployment:
+   - Run Molecule `test` against a live lab inventory.
+   - Current OpenStack coverage includes Keystone token issuance, service catalog endpoint reachability, Nova/Neutron/Cinder service status, Apache listener checks for OpenStack APIs, Nova metadata API checks on `8775`, Ceph integration file checks when enabled, Prometheus target health, and OpenSearch health.
+   - Current Ceph coverage includes cluster health, OSD status, and orchestrator host registration.
+   - Keep smoke tests read-only where possible and fail with targeted messages that identify the failed service or endpoint.
+2. Use Molecule end-to-end workload verification after OpenStack bootstrap:
+   - Enable with `MOLECULE_E2E_VERIFY=true` via Molecule `test` after image,
+     flavor, network, and security group bootstrap resources exist.
+   - Current coverage boots one small VM in OpenStack, waits for `ACTIVE`, verifies tenant network attachment, checks the console log for metadata `503` failures, attaches and detaches a small Cinder volume, then deletes all test resources.
+   - The workload test uses unique resource names and cleanup blocks so failed runs do not leave stale instances or volumes behind.
 3. Adopt secret abstraction:
    - Vault/SOPS with CI secret injection for non-lab environments.
 4. Add architecture/port consistency tests:

--- a/docs/quality-assessment.md
+++ b/docs/quality-assessment.md
@@ -73,7 +73,7 @@ Strengths:
 
 Weak points:
 
-- Multiple hidden couplings (Ceph artifacts consumed from `/tmp`, generated cloud config dependencies).
+- Multiple hidden couplings (optional Ceph artifacts consumed from `/tmp`, generated cloud config dependencies).
 - Some static assumptions that can break portability (hardcoded network, architecture-specific values).
 
 ## 6) Maintainability View

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -22,7 +22,11 @@ Environment bootstrap:
 
 ## 2) Core Lab Provisioning Sequence
 
-### A. Ceph
+### A. Optional Ceph Storage Backend
+
+Ceph is optional for the default lab. Run this stage before OpenStack only when
+you plan to enable Ceph-backed Glance, Cinder, and Nova integration with
+`ceph_enabled: true`.
 
 Ordered playbooks:
 
@@ -59,8 +63,9 @@ One-shot alternative:
 
 Notes:
 
-- `ceph_enabled` defaults to `true` in `deploy_openstack/inventories/local/group_vars/all/common.yml`.
-- `playbook_pre_setup.yml` already loads `ceph_common_vars` and the `ceph` role when Ceph is enabled, so the Ceph export step must have happened first.
+- `ceph_enabled` defaults to `false` in `deploy_openstack/inventories/local/group_vars/all/common.yml`.
+- With the default setting, OpenStack uses Glance file storage and Cinder LVM and does not require the Ceph stage.
+- When Ceph is enabled, `playbook_pre_setup.yml` loads `ceph_common_vars` and the `ceph` role, so the Ceph export step must have happened first.
 - `playbook_deploy.yml` automatically imports `playbook_ceph_integration.yml` when Ceph is enabled, so a manual staged deployment should include it to match the one-shot path.
 
 ### C. OpenStack Bootstrap (tenant resources)
@@ -101,7 +106,8 @@ ip addr show br-provider0
 
 ### B. After Ceph deployment
 
-Check cluster status on the Ceph admin node:
+Run these checks only when the optional Ceph stage was deployed. Check cluster
+status on the Ceph admin node:
 
 ```bash
 cd ansible
@@ -304,7 +310,7 @@ Expected VM set:
 1. Re-running playbooks:
    - Most tasks are designed for repeat runs, but many shell/command tasks force `changed_when: false`, which weakens drift visibility.
 2. Ceph/OpenStack coupling:
-   - If Ceph artifacts in `/tmp/fetch-ceph*` are missing, OpenStack Ceph integration path fails.
+   - If `ceph_enabled: true` and Ceph artifacts in `/tmp/fetch-ceph*` are missing, OpenStack Ceph integration path fails.
 3. Networking:
    - Nested virtualization external access needs host NAT configuration for provider subnet.
 4. Dynamic inventory workloads:
@@ -318,7 +324,8 @@ Expected VM set:
 ## 6) Practical Runbook Advice
 
 1. Keep a strict order:
-   - Vagrant base -> Ceph -> OpenStack -> OpenStack bootstrap -> optional stacks.
+   - Default path: Vagrant base -> OpenStack -> OpenStack bootstrap -> optional stacks.
+   - Ceph path: Vagrant base -> Ceph -> OpenStack with Ceph enabled -> OpenStack bootstrap -> optional stacks.
 2. Validate immediately after each stage:
    - Service health, API endpoint checks, and basic smoke tests (e.g., boot test instance).
 3. Persist artifacts:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -214,6 +214,35 @@ For the Kubernetes lab after `generate_os_client_config local kubernetes_lab`:
 ansible-inventory -i kubernetes_in_openstack/inventories/local/openstack.yml --graph
 ```
 
+### G. Molecule validation gates
+
+Molecule has two separate paths:
+
+- `molecule check` runs inventory variable validation through
+  `molecule/vars_validation.yml`.
+- `molecule test` runs runtime smoke verification through `molecule/verify.yml`.
+
+Run the variable validation gates without needing a deployed runtime smoke test:
+
+```bash
+make validate-openstack
+make validate-ceph
+```
+
+After the lab is deployed, run smoke verification through Molecule `test`:
+
+```bash
+make test-openstack
+make test-ceph
+```
+
+After OpenStack bootstrap creates the image, flavor, network, and security group,
+run the OpenStack workload lifecycle test:
+
+```bash
+MOLECULE_E2E_VERIFY=true make test-openstack
+```
+
 ## 4) Optional Stacks
 
 ### A. Observability (on base lab nodes)

--- a/molecule/ceph/tasks/smoke_verify.yml
+++ b/molecule/ceph/tasks/smoke_verify.yml
@@ -1,0 +1,68 @@
+---
+- name: Check Ceph cluster health
+  ansible.builtin.command:
+    argv:
+      - ceph
+      - health
+      - --format
+      - json
+  become: true
+  register: molecule_ceph_health
+  changed_when: false
+  when: "'ceph_adm' in group_names"
+
+- name: Assert Ceph cluster health is acceptable
+  ansible.builtin.assert:
+    that:
+      - molecule_ceph_health_json.status in molecule_ceph_accepted_health_states | default(['HEALTH_OK', 'HEALTH_WARN'])
+    fail_msg: "Ceph health is not acceptable: {{ molecule_ceph_health.stdout }}"
+  vars:
+    molecule_ceph_health_json: "{{ molecule_ceph_health.stdout | from_json }}"
+  when: "'ceph_adm' in group_names"
+
+- name: Check Ceph OSD status
+  ansible.builtin.command:
+    argv:
+      - ceph
+      - osd
+      - stat
+      - --format
+      - json
+  become: true
+  register: molecule_ceph_osd_stat
+  changed_when: false
+  when: "'ceph_adm' in group_names"
+
+- name: Assert Ceph OSDs are present, up, and in
+  ansible.builtin.assert:
+    that:
+      - molecule_ceph_osd_json.num_osds | int > 0
+      - molecule_ceph_osd_json.num_up_osds | int == molecule_ceph_osd_json.num_osds | int
+      - molecule_ceph_osd_json.num_in_osds | int == molecule_ceph_osd_json.num_osds | int
+    fail_msg: "Ceph OSD status is not healthy: {{ molecule_ceph_osd_stat.stdout }}"
+  vars:
+    molecule_ceph_osd_json: "{{ molecule_ceph_osd_stat.stdout | from_json }}"
+  when: "'ceph_adm' in group_names"
+
+- name: Check Ceph orchestrator hosts
+  ansible.builtin.command:
+    argv:
+      - ceph
+      - orch
+      - host
+      - ls
+      - --format
+      - json
+  become: true
+  register: molecule_ceph_hosts
+  changed_when: false
+  when: "'ceph_adm' in group_names"
+
+- name: Assert Ceph orchestrator has registered hosts
+  ansible.builtin.assert:
+    that:
+      - molecule_ceph_host_items | length > 0
+    fail_msg: "Ceph orchestrator host list is empty: {{ molecule_ceph_hosts.stdout }}"
+  vars:
+    molecule_ceph_host_items: "{{ molecule_ceph_hosts.stdout | from_json }}"
+  when: "'ceph_adm' in group_names"

--- a/molecule/config.yml
+++ b/molecule/config.yml
@@ -23,10 +23,10 @@ ansible:
     cleanup: $ROOT_DIR/molecule/cleanup.yml
     prepare:
     side_effect:
-    verify: $ROOT_DIR/molecule/vars_validation.yml
+    verify: $ROOT_DIR/molecule/verify.yml
 scenario:
-  test_sequence:
-    - verify
+  check_sequence:
+    - verify $ROOT_DIR/molecule/vars_validation.yml
     - cleanup
   create_sequence:
     - create
@@ -34,5 +34,7 @@ scenario:
     - converge
   destroy_sequence:
     - destroy
+  test_sequence:
+    - verify
 verifier:
   name: ansible

--- a/molecule/destroy.yml
+++ b/molecule/destroy.yml
@@ -1,0 +1,11 @@
+---
+- name: Destroy
+  hosts: localhost
+  gather_facts: false
+  vars:
+    root_dir: "{{ lookup('ansible.builtin.env', 'ROOT_DIR') }}"
+    scenario: "{{ lookup('ansible.builtin.env', 'SCENARIO') }}"
+  tasks:
+    - name: Destroy
+      ansible.builtin.debug:
+        msg: Destroying scenario {{ scenario }}

--- a/molecule/openstack/results/local/expected/common_vars.json
+++ b/molecule/openstack/results/local/expected/common_vars.json
@@ -17,7 +17,7 @@
         "mgmtnet_ip_address": "192.168.121.9",
         "provider_ip_address": "192.168.123.9"
     },
-    "ceph_enabled": true,
+    "ceph_enabled": false,
     "compute01": {
         "cpus": 10,
         "disks": 25,

--- a/molecule/openstack/tasks/e2e_workload_verify.yml
+++ b/molecule/openstack/tasks/e2e_workload_verify.yml
@@ -1,0 +1,261 @@
+---
+- name: Set OpenStack CLI environment for end-to-end verification
+  ansible.builtin.set_fact:
+    molecule_openstack_auth_env:
+      OS_AUTH_URL: http://{{ controller01_host_addr }}:5000/v3
+      OS_IDENTITY_API_VERSION: "3"
+      OS_INTERFACE: public
+      OS_PASSWORD: "{{ os_keystone_password }}"
+      OS_PROJECT_DOMAIN_NAME: Default
+      OS_PROJECT_NAME: admin
+      OS_REGION_NAME: RegionOne
+      OS_USER_DOMAIN_NAME: Default
+      OS_USERNAME: admin
+    molecule_e2e_run_id: "{{ lookup('ansible.builtin.password', '/dev/null chars=ascii_lowercase,digits length=8') }}"
+  when: "'controller' in group_names"
+  no_log: true
+
+- name: Set OpenStack end-to-end resource names
+  ansible.builtin.set_fact:
+    molecule_e2e_server_name: "{{ molecule_e2e_name_prefix | default('molecule-e2e') }}-{{ molecule_e2e_run_id }}"
+    molecule_e2e_volume_name: "{{ molecule_e2e_name_prefix | default('molecule-e2e') }}-volume-{{ molecule_e2e_run_id }}"
+    molecule_e2e_image_name: "{{ molecule_e2e_image | default(lookup('ansible.builtin.env', 'MOLECULE_E2E_IMAGE') | default('vm_image01', true)) }}"
+    molecule_e2e_flavor_name: "{{ molecule_e2e_flavor | default(lookup('ansible.builtin.env', 'MOLECULE_E2E_FLAVOR') | default('small', true)) }}"
+    molecule_e2e_network_name: "{{ molecule_e2e_network | default(lookup('ansible.builtin.env', 'MOLECULE_E2E_NETWORK') | default('private', true)) }}"
+    molecule_e2e_security_group_name: >-
+      {{ molecule_e2e_security_group |
+      default(lookup('ansible.builtin.env', 'MOLECULE_E2E_SECURITY_GROUP') |
+      default('openstack_lab', true)) }}"
+    molecule_e2e_volume_size: "{{ molecule_e2e_volume_size_gb | default(lookup('ansible.builtin.env', 'MOLECULE_E2E_VOLUME_SIZE_GB') | default('1', true)) }}"
+  when: "'controller' in group_names"
+
+- name: Run OpenStack end-to-end workload lifecycle
+  when: "'controller' in group_names"
+  block:
+    - name: Validate OpenStack end-to-end prerequisites
+      ansible.builtin.command:
+        argv: "{{ item.argv }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      loop:
+        - label: image {{ molecule_e2e_image_name }}
+          argv:
+            - openstack
+            - image
+            - show
+            - "{{ molecule_e2e_image_name }}"
+            - -f
+            - value
+        - label: flavor {{ molecule_e2e_flavor_name }}
+          argv:
+            - openstack
+            - flavor
+            - show
+            - "{{ molecule_e2e_flavor_name }}"
+            - -f
+            - value
+        - label: network {{ molecule_e2e_network_name }}
+          argv:
+            - openstack
+            - network
+            - show
+            - "{{ molecule_e2e_network_name }}"
+            - -f
+            - value
+        - label: security group {{ molecule_e2e_security_group_name }}
+          argv:
+            - openstack
+            - security
+            - group
+            - show
+            - "{{ molecule_e2e_security_group_name }}"
+            - -f
+            - value
+      loop_control:
+        label: "{{ item.label }}"
+      changed_when: false
+
+    - name: Boot OpenStack end-to-end test instance
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - server
+          - create
+          - -f
+          - json
+          - --image
+          - "{{ molecule_e2e_image_name }}"
+          - --flavor
+          - "{{ molecule_e2e_flavor_name }}"
+          - --network
+          - "{{ molecule_e2e_network_name }}"
+          - --security-group
+          - "{{ molecule_e2e_security_group_name }}"
+          - --wait
+          - "{{ molecule_e2e_server_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_server_create
+      changed_when: true
+
+    - name: Show OpenStack end-to-end test instance
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - server
+          - show
+          - "{{ molecule_e2e_server_name }}"
+          - -f
+          - json
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_server_show
+      changed_when: false
+
+    - name: Assert OpenStack end-to-end test instance is active and attached to network
+      ansible.builtin.assert:
+        that:
+          - molecule_e2e_server_json.status == 'ACTIVE'
+          - molecule_e2e_network_name in molecule_e2e_server_json.addresses
+        fail_msg: "OpenStack test instance is not active or lacks network attachment: {{ molecule_e2e_server_show.stdout }}"
+      vars:
+        molecule_e2e_server_json: "{{ molecule_e2e_server_show.stdout | from_json }}"
+
+    - name: Wait before reading guest console metadata output
+      ansible.builtin.pause:
+        seconds: "{{ molecule_e2e_console_wait_seconds | default(30) }}"
+
+    - name: Read OpenStack end-to-end instance console log
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - console
+          - log
+          - show
+          - "{{ molecule_e2e_server_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_console_log
+      changed_when: false
+
+    - name: Assert guest console does not show metadata 503 failures
+      ansible.builtin.assert:
+        that:
+          - >-
+            molecule_e2e_console_log.stdout is not search(molecule_e2e_metadata_failure_regex |
+            default('Endpoint returned a 503 error|169\\.254\\.169\\.254/openstack.*503|metadata.*503'))
+        fail_msg: "Guest console shows OpenStack metadata failure: {{ molecule_e2e_console_log.stdout }}"
+
+    - name: Create OpenStack end-to-end test volume
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - volume
+          - create
+          - -f
+          - json
+          - --size
+          - "{{ molecule_e2e_volume_size }}"
+          - --wait
+          - "{{ molecule_e2e_volume_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_volume_create
+      changed_when: true
+
+    - name: Attach OpenStack end-to-end test volume
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - server
+          - add
+          - volume
+          - "{{ molecule_e2e_server_name }}"
+          - "{{ molecule_e2e_volume_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_volume_attach
+      changed_when: true
+
+    - name: Wait for OpenStack end-to-end test volume to attach
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - volume
+          - show
+          - "{{ molecule_e2e_volume_name }}"
+          - -f
+          - value
+          - -c
+          - status
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_volume_status
+      changed_when: false
+      retries: "{{ molecule_e2e_volume_retries | default(20) }}"
+      delay: "{{ molecule_e2e_volume_delay | default(6) }}"
+      until: molecule_e2e_volume_status.stdout == 'in-use'
+
+    - name: Detach OpenStack end-to-end test volume
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - server
+          - remove
+          - volume
+          - "{{ molecule_e2e_server_name }}"
+          - "{{ molecule_e2e_volume_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_volume_detach
+      changed_when: true
+
+    - name: Wait for OpenStack end-to-end test volume to detach
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - volume
+          - show
+          - "{{ molecule_e2e_volume_name }}"
+          - -f
+          - value
+          - -c
+          - status
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_volume_detached_status
+      changed_when: false
+      retries: "{{ molecule_e2e_volume_retries | default(20) }}"
+      delay: "{{ molecule_e2e_volume_delay | default(6) }}"
+      until: molecule_e2e_volume_detached_status.stdout == 'available'
+  always:
+    - name: Remove OpenStack end-to-end test volume attachment if present
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - server
+          - remove
+          - volume
+          - "{{ molecule_e2e_server_name }}"
+          - "{{ molecule_e2e_volume_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_cleanup_detach
+      changed_when: molecule_e2e_cleanup_detach.rc == 0
+      failed_when: false
+
+    - name: Delete OpenStack end-to-end test server
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - server
+          - delete
+          - --wait
+          - "{{ molecule_e2e_server_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_cleanup_server
+      changed_when: molecule_e2e_cleanup_server.rc == 0
+      failed_when: false
+
+    - name: Delete OpenStack end-to-end test volume
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - volume
+          - delete
+          - --force
+          - "{{ molecule_e2e_volume_name }}"
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_cleanup_volume
+      changed_when: molecule_e2e_cleanup_volume.rc == 0
+      failed_when: false

--- a/molecule/openstack/tasks/e2e_workload_verify.yml
+++ b/molecule/openstack/tasks/e2e_workload_verify.yml
@@ -25,7 +25,7 @@
     molecule_e2e_security_group_name: >-
       {{ molecule_e2e_security_group |
       default(lookup('ansible.builtin.env', 'MOLECULE_E2E_SECURITY_GROUP') |
-      default('openstack_lab', true)) }}"
+      default('openstack_lab', true)) }}
     molecule_e2e_volume_size: "{{ molecule_e2e_volume_size_gb | default(lookup('ansible.builtin.env', 'MOLECULE_E2E_VOLUME_SIZE_GB') | default('1', true)) }}"
   when: "'controller' in group_names"
 
@@ -152,11 +152,28 @@
           - json
           - --size
           - "{{ molecule_e2e_volume_size }}"
-          - --wait
           - "{{ molecule_e2e_volume_name }}"
       environment: "{{ molecule_openstack_auth_env }}"
       register: molecule_e2e_volume_create
       changed_when: true
+
+    - name: Wait for OpenStack end-to-end test volume to be available
+      ansible.builtin.command:
+        argv:
+          - openstack
+          - volume
+          - show
+          - "{{ molecule_e2e_volume_name }}"
+          - -f
+          - value
+          - -c
+          - status
+      environment: "{{ molecule_openstack_auth_env }}"
+      register: molecule_e2e_volume_status_available
+      changed_when: false
+      retries: "{{ molecule_e2e_volume_retries | default(15) }}"
+      delay: "{{ molecule_e2e_volume_delay | default(5) }}"
+      until: molecule_e2e_volume_status_available.stdout == 'available'
 
     - name: Attach OpenStack end-to-end test volume
       ansible.builtin.command:

--- a/molecule/openstack/tasks/smoke_verify.yml
+++ b/molecule/openstack/tasks/smoke_verify.yml
@@ -1,0 +1,322 @@
+---
+- name: Set OpenStack CLI environment for smoke verification
+  ansible.builtin.set_fact:
+    molecule_openstack_auth_env:
+      OS_AUTH_URL: http://{{ controller01_host_addr }}:5000/v3
+      OS_IDENTITY_API_VERSION: "3"
+      OS_INTERFACE: public
+      OS_PASSWORD: "{{ os_keystone_password }}"
+      OS_PROJECT_DOMAIN_NAME: Default
+      OS_PROJECT_NAME: admin
+      OS_REGION_NAME: RegionOne
+      OS_USER_DOMAIN_NAME: Default
+      OS_USERNAME: admin
+  when: "'controller' in group_names"
+  no_log: true
+
+- name: Check OpenStack API listener ports
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ item.port }}"
+    timeout: 5
+  loop:
+    - name: Keystone
+      port: 5000
+    - name: Nova compute API
+      port: 8774
+    - name: Nova metadata API
+      port: 8775
+    - name: Cinder API
+      port: 8776
+    - name: Placement API
+      port: 8778
+    - name: Neutron API
+      port: 9696
+  loop_control:
+    label: "{{ item.name }}:{{ item.port }}"
+  when: "'controller' in group_names"
+
+- name: Check Keystone token issuance
+  ansible.builtin.command:
+    argv:
+      - openstack
+      - token
+      - issue
+      - -f
+      - value
+      - -c
+      - id
+  environment: "{{ molecule_openstack_auth_env }}"
+  register: molecule_keystone_token
+  changed_when: false
+  when: "'controller' in group_names"
+
+- name: Assert Keystone returned a token id
+  ansible.builtin.assert:
+    that:
+      - molecule_keystone_token.stdout | length > 0
+    fail_msg: Keystone token issuance returned an empty token id.
+  when: "'controller' in group_names"
+
+- name: Check OpenStack service catalog endpoints
+  ansible.builtin.command:
+    argv:
+      - openstack
+      - endpoint
+      - list
+      - --service
+      - "{{ item.service }}"
+      - -f
+      - value
+      - -c
+      - URL
+  environment: "{{ molecule_openstack_auth_env }}"
+  loop:
+    - service: identity
+      expected_port: 5000
+    - service: compute
+      expected_port: 8774
+    - service: placement
+      expected_port: 8778
+    - service: network
+      expected_port: 9696
+    - service: volumev3
+      expected_port: 8776
+  loop_control:
+    label: "{{ item.service }}"
+  register: molecule_endpoint_checks
+  changed_when: false
+  when: "'controller' in group_names"
+
+- name: Assert OpenStack service catalog endpoints are reachable in catalog
+  ansible.builtin.assert:
+    that:
+      - item.stdout | length > 0
+      - (':' ~ item.item.expected_port) in item.stdout
+    fail_msg: Service {{ item.item.service }} endpoint is missing or does not include port {{ item.item.expected_port }}.
+  loop: "{{ molecule_endpoint_checks.results }}"
+  loop_control:
+    label: "{{ item.item.service }}"
+  when: "'controller' in group_names"
+
+- name: Check Nova service health
+  ansible.builtin.command:
+    argv:
+      - openstack
+      - compute
+      - service
+      - list
+      - -f
+      - json
+  environment: "{{ molecule_openstack_auth_env }}"
+  register: molecule_nova_services
+  changed_when: false
+  when: "'controller' in group_names"
+
+- name: Assert Nova services are up and enabled
+  ansible.builtin.assert:
+    that:
+      - molecule_nova_service_items | length > 0
+      - molecule_nova_service_items | selectattr('State', 'ne', 'up') | list | length == 0
+      - molecule_nova_service_items | selectattr('Status', 'ne', 'enabled') | list | length == 0
+    fail_msg: "Nova service health check failed: {{ molecule_nova_services.stdout }}"
+  vars:
+    molecule_nova_service_items: "{{ molecule_nova_services.stdout | from_json }}"
+  when: "'controller' in group_names"
+
+- name: Check Neutron agent health
+  ansible.builtin.command:
+    argv:
+      - openstack
+      - network
+      - agent
+      - list
+      - -f
+      - json
+  environment: "{{ molecule_openstack_auth_env }}"
+  register: molecule_neutron_agents
+  changed_when: false
+  when: "'controller' in group_names"
+
+- name: Assert Neutron agents are alive and up
+  ansible.builtin.assert:
+    that:
+      - molecule_neutron_agent_items | length > 0
+    fail_msg: "Neutron agent health check failed: {{ molecule_neutron_agents.stdout }}"
+  vars:
+    molecule_neutron_agent_items: "{{ molecule_neutron_agents.stdout | from_json }}"
+  when: "'controller' in group_names"
+
+- name: Assert each Neutron agent is alive and up
+  ansible.builtin.assert:
+    that:
+      - (item.get('Alive', '') | string | lower) in molecule_neutron_alive_values
+      - (item.get('State', '') | string | lower) in molecule_neutron_state_values
+    fail_msg: "Neutron agent is not healthy: {{ item }}"
+  vars:
+    molecule_neutron_agent_items: "{{ molecule_neutron_agents.stdout | from_json }}"
+    molecule_neutron_alive_values:
+      - ":-)"
+      - "true"
+      - up
+      - alive
+      - "yes"
+    molecule_neutron_state_values:
+      - up
+      - "true"
+      - enabled
+  loop: "{{ molecule_neutron_agent_items }}"
+  loop_control:
+    label: "{{ item.get('Host', item.get('host', item.get('ID', 'unknown'))) }} {{ item.get('Agent Type', item.get('Binary', 'agent')) }}"
+  when: "'controller' in group_names"
+
+- name: Check Cinder service health
+  ansible.builtin.command:
+    argv:
+      - openstack
+      - volume
+      - service
+      - list
+      - -f
+      - json
+  environment: "{{ molecule_openstack_auth_env }}"
+  register: molecule_cinder_services
+  changed_when: false
+  when: "'controller' in group_names"
+
+- name: Assert Cinder services are up and enabled
+  ansible.builtin.assert:
+    that:
+      - molecule_cinder_service_items | length > 0
+      - molecule_cinder_service_items | selectattr('State', 'ne', 'up') | list | length == 0
+      - molecule_cinder_service_items | selectattr('Status', 'ne', 'enabled') | list | length == 0
+    fail_msg: "Cinder service health check failed: {{ molecule_cinder_services.stdout }}"
+  vars:
+    molecule_cinder_service_items: "{{ molecule_cinder_services.stdout | from_json }}"
+  when: "'controller' in group_names"
+
+- name: Check Nova metadata API response
+  ansible.builtin.uri:
+    url: http://127.0.0.1:8775/openstack
+    method: GET
+    return_content: false
+    status_code:
+      - 200
+      - 300
+      - 400
+      - 404
+  register: molecule_metadata_api
+  when: "'controller' in group_names"
+
+- name: Assert Nova metadata API does not return 503
+  ansible.builtin.assert:
+    that:
+      - molecule_metadata_api.status | int != 503
+    fail_msg: Nova metadata API returned 503 on controller localhost.
+  when: "'controller' in group_names"
+
+- name: Check OpenStack Ceph integration files when Ceph is enabled
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  vars:
+    molecule_openstack_ceph_files: >-
+      {{
+        ['/etc/ceph/ceph.conf']
+        + (['/etc/ceph/ceph.client.glance.keyring'] if 'controller' in group_names else [])
+        + (['/etc/ceph/ceph.client.cinder.keyring'] if ('compute' in group_names or 'storage' in group_names) else [])
+      }}
+  loop: "{{ molecule_openstack_ceph_files }}"
+  register: molecule_openstack_ceph_file_stats
+  when:
+    - ceph_enabled | default(false) | bool
+    - molecule_openstack_ceph_files | length > 0
+
+- name: Assert OpenStack Ceph integration files are present
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+    fail_msg: "Expected Ceph integration file is missing: {{ item.item }}"
+  loop: "{{ molecule_openstack_ceph_file_stats.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - ceph_enabled | default(false) | bool
+
+- name: Check whether Prometheus is deployed
+  ansible.builtin.command:
+    argv:
+      - systemctl
+      - is-active
+      - prometheus
+  register: molecule_prometheus_service
+  changed_when: false
+  failed_when: false
+  when: "'controller' in group_names"
+
+- name: Check Prometheus readiness when deployed
+  ansible.builtin.uri:
+    url: http://127.0.0.1:9090/-/ready
+    method: GET
+    status_code: 200
+    return_content: false
+  when:
+    - "'controller' in group_names"
+    - molecule_prometheus_service.rc == 0
+
+- name: Check Prometheus active target health when deployed
+  ansible.builtin.uri:
+    url: http://127.0.0.1:9090/api/v1/targets?state=active
+    method: GET
+    status_code: 200
+    return_content: true
+  register: molecule_prometheus_targets
+  when:
+    - "'controller' in group_names"
+    - molecule_prometheus_service.rc == 0
+
+- name: Assert Prometheus active targets are up
+  ansible.builtin.assert:
+    that:
+      - molecule_prometheus_targets.json.status == 'success'
+      - molecule_prometheus_active_targets | selectattr('health', 'ne', 'up') | list | length == 0
+    fail_msg: "Prometheus has unhealthy active targets: {{ molecule_prometheus_targets.json.data.activeTargets | default([]) }}"
+  vars:
+    molecule_prometheus_active_targets: "{{ molecule_prometheus_targets.json.data.activeTargets | default([]) }}"
+  when:
+    - "'controller' in group_names"
+    - molecule_prometheus_service.rc == 0
+
+- name: Check whether OpenSearch is deployed
+  ansible.builtin.command:
+    argv:
+      - systemctl
+      - is-active
+      - opensearch
+  register: molecule_opensearch_service
+  changed_when: false
+  failed_when: false
+  when: "'controller' in group_names"
+
+- name: Check OpenSearch cluster health when deployed
+  ansible.builtin.uri:
+    url: https://127.0.0.1:{{ molecule_opensearch_api_port | default(9920) }}/_cluster/health
+    method: GET
+    user: "{{ molecule_opensearch_user | default('admin') }}"
+    password: "{{ molecule_opensearch_password | default('admin12345') }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: 200
+    return_content: true
+  register: molecule_opensearch_health
+  when:
+    - "'controller' in group_names"
+    - molecule_opensearch_service.rc == 0
+
+- name: Assert OpenSearch health is acceptable
+  ansible.builtin.assert:
+    that:
+      - molecule_opensearch_health.json.status in molecule_opensearch_accepted_health_states | default(['green', 'yellow'])
+    fail_msg: "OpenSearch health is not acceptable: {{ molecule_opensearch_health.json }}"
+  when:
+    - "'controller' in group_names"
+    - molecule_opensearch_service.rc == 0

--- a/molecule/vars_validation.yml
+++ b/molecule/vars_validation.yml
@@ -6,6 +6,7 @@
     root_dir: "{{ lookup('ansible.builtin.env', 'ROOT_DIR') }}"
     target_env: "{{ lookup('ansible.builtin.env', 'TARGET_ENV') }}"
     excluded_vars:
+      - ^_raw_params$
       - ^molecule
       - ^ansible_config_file$
       - ^ansible_facts$

--- a/molecule/verify.yml
+++ b/molecule/verify.yml
@@ -1,0 +1,41 @@
+---
+- name: Run Molecule runtime verification
+  hosts: all
+  gather_facts: false
+  vars:
+    ceph_enabled: "{{ lookup('ansible.builtin.env', 'CEPH_ENABLED') | default('false', true) | bool }}"
+    molecule_run_e2e_verify: "{{ lookup('ansible.builtin.env', 'MOLECULE_E2E_VERIFY') | default('false', true) | bool }}"
+  tasks:
+    - name: Find scenario smoke verification tasks
+      ansible.builtin.set_fact:
+        smoke_verify_tasks_file: "{{ lookup('ansible.builtin.first_found', smoke_verify_lookup, errors='ignore') }}"
+      vars:
+        smoke_verify_lookup:
+          files:
+            - smoke_verify.yml
+          paths:
+            - "{{ molecule_scenario_directory }}/tasks"
+
+    - name: Run scenario smoke verification tasks
+      ansible.builtin.include_tasks:
+        file: "{{ smoke_verify_tasks_file }}"
+      when:
+        - smoke_verify_tasks_file | default('') | length > 0
+
+    - name: Find optional scenario end-to-end verification tasks
+      ansible.builtin.set_fact:
+        e2e_verify_tasks_file: "{{ lookup('ansible.builtin.first_found', e2e_verify_lookup, errors='ignore') }}"
+      vars:
+        e2e_verify_lookup:
+          files:
+            - e2e_workload_verify.yml
+          paths:
+            - "{{ molecule_scenario_directory }}/tasks"
+      when: molecule_run_e2e_verify
+
+    - name: Run optional scenario end-to-end verification tasks
+      ansible.builtin.include_tasks:
+        file: "{{ e2e_verify_tasks_file }}"
+      when:
+        - molecule_run_e2e_verify
+        - e2e_verify_tasks_file | default('') | length > 0


### PR DESCRIPTION
  test(molecule): split validation and runtime verification
    
  Run inventory snapshot validation through molecule check and move runtime checks
  to molecule test. Add default OpenStack and Ceph smoke verification plus an
  optional OpenStack e2e workload lifecycle gated by MOLECULE_E2E_VERIFY.

  docs: refresh Molecule validation workflow

  Document the check/test split, default smoke verification, optional e2e workload
  verification, and the related Makefile targets.

  chore(openstack): disable Ceph by default in local inventory

  Set ceph_enabled to false for the local OpenStack inventory and update the
  Molecule expected common-vars snapshot.

  style(ansible): normalize task quoting

  Normalize YAML quoting for modes, string comparisons, empty strings, and list
  literals across CI/CD, OpenStack, OpenSearch, Kubernetes, and shared roles